### PR TITLE
fix multi-target publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,16 +36,22 @@ jobs:
         shell: bash
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
-      # Full solution restore for win-x64 (covers all projects including PubUtilsUI).
-      - name: Restore (win-x64)
-        run: dotnet restore NEShim/NEShim.sln -r win-x64 -p:PublishReadyToRun=true
-
-      # Per-project restore for linux-x64 — PubUtilsUI targets net9.0-windows
-      # and cannot be restored for a non-Windows RID.
-      - name: Restore (linux-x64)
-        run: |
-          dotnet restore NEShim/NEShim/NEShim.csproj -r linux-x64 -p:PublishReadyToRun=true
-          dotnet restore NEShim/NEShim.PubUtils/NEShim.PubUtils.csproj -r linux-x64
+      # One solution-wide restore, no -r flag: NEShim.csproj/NEShim.PubUtils.csproj declare
+      # <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers> (NEShim.PubUtilsUI.csproj
+      # declares win-x64 only, being Windows Forms) directly in the project files, so this single
+      # restore populates every RID-specific target each project needs, all in one assets file.
+      #
+      # Previously this was two separate `dotnet restore -r <rid>` calls (win-x64, then
+      # linux-x64). That doesn't just miss covering both RIDs — passing -r to `dotnet restore`
+      # overrides a project's own RuntimeIdentifiers list and restricts that restore to the one
+      # RID given, so the second call was silently overwriting the first call's win-x64 target in
+      # NEShim.csproj/NEShim.PubUtils.csproj's obj/project.assets.json with a linux-x64-only one.
+      # The later `dotnet publish --no-restore -r win-x64` steps then failed with NETSDK1047
+      # ("doesn't have a target for net9.0/win-x64") — reproduced locally by running this exact
+      # sequence, and confirmed fixed by removing -r here and relying on the projects' own
+      # RuntimeIdentifiers declarations instead.
+      - name: Restore
+        run: dotnet restore NEShim/NEShim.sln -p:PublishReadyToRun=true
 
       - name: Test
         run: >

--- a/NEShim/NEShim.PubUtils/NEShim.PubUtils.csproj
+++ b/NEShim/NEShim.PubUtils/NEShim.PubUtils.csproj
@@ -6,6 +6,11 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>pub-utils</AssemblyName>
+        <!-- See NEShim.csproj's identical RuntimeIdentifiers comment: release.yml restores this
+             project separately per RID (win-x64, then linux-x64) ahead of separate no-restore
+             publish calls; without both RIDs declared here the later restore silently overwrites
+             the earlier one's assets file. Reproduced locally. -->
+        <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NEShim/NEShim.PubUtilsUI/NEShim.PubUtilsUI.csproj
+++ b/NEShim/NEShim.PubUtilsUI/NEShim.PubUtilsUI.csproj
@@ -7,6 +7,10 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>pub-utils-ui</AssemblyName>
+        <!-- Windows Forms only runs on win-x64; see NEShim.csproj's RuntimeIdentifiers comment
+             for why this needs to be declared at all once release.yml's restore steps stop
+             passing an explicit -r value. -->
+        <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NEShim/NEShim/NEShim.csproj
+++ b/NEShim/NEShim/NEShim.csproj
@@ -9,6 +9,18 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <ApplicationIcon>icon.ico</ApplicationIcon>
+        <!-- Required for release.yml's two step restore then publish flow: it restores this
+             project once per RID in separate "dotnet restore -r rid" calls (win-x64, then
+             linux-x64), ahead of separate "dotnet publish (no restore) -r rid" calls later in
+             the same job. Without RuntimeIdentifiers (plural) declared here, each single-RID
+             restore call OVERWRITES this project's obj/project.assets.json rather than adding to
+             it, so the later linux-x64 restore silently wipes out the win-x64 target the earlier
+             restore wrote; the subsequent win-x64 publish then fails with NETSDK1047 ("doesn't
+             have a target for net9.0/win-x64"), reproduced locally by running the exact same
+             restore/publish sequence release.yml does. Declaring both RIDs here makes every
+             restore call (regardless of which single -r value it passes) populate both targets in
+             the same assets file, so restore order no longer matters. -->
+        <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     </PropertyGroup>
 
     <!-- Target-platform detection for the conditions below. Deliberately keyed on


### PR DESCRIPTION
moving to linux and doing win64 and linux broke the .net compile, need to set runtimeidentifiers